### PR TITLE
FIx "Cannot set a non-string value as the PAD token" problem

### DIFF
--- a/model.py
+++ b/model.py
@@ -38,7 +38,7 @@ class SpanLM(object):
         print("Max length: {}".format(self.max_length))
         self.model = self.model.to(self.device)
         self.tokenizer = AutoTokenizer.from_pretrained(pretrained)
-        self.tokenizer.pad_token = 0
+        self.tokenizer.pad_token_id = 0
         self.tokenizer.padding_side = "left"
         self.batch_size = batch_size
         print("Batch size: {}".format(batch_size))


### PR DESCRIPTION
When I ran your script, I met the problem described in #1. I checked your code and found that you wrongly set `pad_token` to 0 rather than `pad_token_id`. So I submit this PR to fix this issue :)